### PR TITLE
feat(summary): expand boilerplate filters for routine notices

### DIFF
--- a/scraper/summarize.py
+++ b/scraper/summarize.py
@@ -65,6 +65,21 @@ _BOILERPLATE_PATTERNS = [
         r"\bpublic comment(s)?\b",
         r"\badjourn(ment)?\b",
         r"\bconsent calendar\b",
+        r"\bagenda items? are subject to change\b",
+        r"\bsubject to change in order and timing\b",
+        r"\bsubmit comments? on agenda items? via email\b",
+        r"\bmeeting will be broadcast live\b",
+        r"\bchannel\s*18\b",
+        r"\bfacebook live\b",
+        r"\bauxiliary aids\b",
+        r"\brequest (them|accommodations?) at least\s*\d+\s*hours in advance\b",
+        r"\binvocation\b",
+        r"\bagenda will be reviewed and approved\b",
+        r"\baddendum (to the )?agenda\b",
+        r"\bdepartment and committee reports?\b",
+        r"\bnon-action items?\b",
+        r"\bcouncilmembers? .*open discussion\b",
+        r"\belected officials? will provide comments\b",
     ]
 ]
 

--- a/tests/test_summarize_filters.py
+++ b/tests/test_summarize_filters.py
@@ -28,6 +28,27 @@ class TestSummaryFiltering(unittest.TestCase):
         out = _clean_summary_bullets(bullets, meeting, max_bullets=10)
         self.assertEqual(out, ["Approve budget amendment for transit operations"])
 
+    def test_drops_common_notice_boilerplate(self):
+        meeting = {"date": "2026-03-10", "start_time_local": "6:00 PM", "location": "City Hall"}
+        bullets = [
+            "All agenda items are subject to change in order and timing.",
+            "Citizens can submit comments on agenda items via email before the meeting.",
+            "The meeting will be broadcast live on Channel 18 and Facebook Live.",
+            "A resolution to approve a downtown housing contract will be considered.",
+        ]
+        out = _clean_summary_bullets(bullets, meeting, max_bullets=10)
+        self.assertEqual(out, ["A resolution to approve a downtown housing contract will be considered."])
+
+    def test_keeps_specific_executive_session_context(self):
+        meeting = {"date": "2026-03-10", "start_time_local": "6:00 PM", "location": "City Hall"}
+        bullets = [
+            "An executive session is scheduled to discuss confidential matters.",
+            "The case discussed in executive session is Smith v. City, Case No. 2026CV12345.",
+        ]
+        out = _clean_summary_bullets(bullets, meeting, max_bullets=10)
+        self.assertIn("An executive session is scheduled to discuss confidential matters.", out)
+        self.assertIn("The case discussed in executive session is Smith v. City, Case No. 2026CV12345.", out)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up for issue #2 based on live meetings.json review.

## What this adds
- Filters additional obvious non-newsworthy boilerplate, including:
  - "agenda items are subject to change"
  - "submit comments via email"
  - broadcast/platform notices (Channel 18, Facebook Live)
  - accessibility notice boilerplate
  - invocation
  - generic agenda/addendum/non-action-report housekeeping lines

## Safety/quality
- Keeps substantive executive-session context when specific details exist.
- Test suite expanded to cover these new filter classes.

## Validation
- `python -m unittest tests/test_summarize_filters.py` -> OK (4 tests)

Refs #2