### PR TITLE
feat(summary): routine-toggle UI + stronger newsworthiness filtering

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -241,6 +241,10 @@ jobs:
               <label><div style="font-weight:600;">Source</div>
                 <select id="sourceSelect"><option value="">All sources</option></select>
               </label>
+              <label style="display:flex;align-items:end;gap:.5rem;">
+                <input id="routineToggle" type="checkbox" />
+                <span style="font-weight:600;">Show routine items</span>
+              </label>
             </section>
             <ul id="results"></ul>
           ''')
@@ -302,6 +306,7 @@ jobs:
           
             const citySel = document.getElementById('citySelect');
             const srcSel  = document.getElementById('sourceSelect');
+            const routineToggle = document.getElementById('routineToggle');
             const results = document.getElementById('results');
             const staticList = document.getElementById('static-list');
           
@@ -344,6 +349,7 @@ jobs:
             const url = new URL(location.href);
             citySel.value = url.searchParams.get('city') ?? localStorage.getItem('mw_city') ?? '';
             srcSel.value  = url.searchParams.get('source') ?? localStorage.getItem('mw_source') ?? '';
+            routineToggle.checked = (url.searchParams.get('showRoutine') ?? localStorage.getItem('mw_showRoutine') ?? '0') === '1';
           
             function inferType(title=''){
               const t = String(title).toLowerCase();
@@ -370,24 +376,30 @@ jobs:
               const when = (function(w){ return w ? '🕒 ' + w : ''; })(formatWhen(m));
               return [city, agenda, source, type, when].filter(Boolean).join('  •  ');
             }
-            function bulletsHTML(m){
-              const arr = Array.isArray(m.agenda_summary) ? m.agenda_summary
+            function bulletsHTML(m, showRoutine){
+              const keep = Array.isArray(m.agenda_summary) ? m.agenda_summary
                          : (typeof m.agenda_summary === 'string' ? m.agenda_summary.split(/\\n+/).filter(Boolean) : []);
-              if (!arr.length) return '';
-              return '<ul>' + arr.map(b => '<li>'+b+'</li>').join('') + '</ul>';
+              const routine = Array.isArray(m.agenda_summary_routine) ? m.agenda_summary_routine
+                            : (typeof m.agenda_summary_routine === 'string' ? m.agenda_summary_routine.split(/\\n+/).filter(Boolean) : []);
+              const keepHtml = keep.length ? '<ul>' + keep.map(b => '<li>'+b+'</li>').join('') + '</ul>' : '';
+              if (!showRoutine || !routine.length) return keepHtml;
+              const routineHtml = '<details style="margin-top:.4rem"><summary style="cursor:pointer;color:#666">Routine items ('+routine.length+')</summary><ul style="color:#666">' + routine.map(b => '<li>'+b+'</li>').join('') + '</ul></details>';
+              return keepHtml + routineHtml;
             }
             function syncState(){
-              const c = citySel.value, s = srcSel.value;
+              const c = citySel.value, s = srcSel.value, showRoutine = routineToggle.checked;
               localStorage.setItem('mw_city', c);
               localStorage.setItem('mw_source', s);
+              localStorage.setItem('mw_showRoutine', showRoutine ? '1' : '0');
               const u = new URL(location.href);
               c ? u.searchParams.set('city', c) : u.searchParams.delete('city');
               s ? u.searchParams.set('source', s) : u.searchParams.delete('source');
+              showRoutine ? u.searchParams.set('showRoutine', '1') : u.searchParams.delete('showRoutine');
               history.replaceState({}, '', u);
             }
             function render(){
               syncState();
-              const c = citySel.value, s = srcSel.value;
+              const c = citySel.value, s = srcSel.value, showRoutine = routineToggle.checked;
               const filtered = items.filter(m =>
                 (!c || (m.city||'') === c) && (!s || (m.provider||'') === s)
               );
@@ -411,13 +423,14 @@ jobs:
                   <div class="meta" style="margin-bottom:.4rem;display:flex;flex-wrap:wrap;gap:.5rem .75rem;">
                     ${headerLine(m)}
                   </div>
-                  ${bulletsHTML(m)}
+                  ${bulletsHTML(m, showRoutine)}
                 `;
                 results.appendChild(li);
               }
             }
             citySel.addEventListener('change', render);
             srcSel.addEventListener('change', render);
+            routineToggle.addEventListener('change', render);
             render();
           })();
           </script>''')

--- a/scraper/summarize.py
+++ b/scraper/summarize.py
@@ -80,6 +80,11 @@ _BOILERPLATE_PATTERNS = [
         r"\bnon-action items?\b",
         r"\bcouncilmembers? .*open discussion\b",
         r"\belected officials? will provide comments\b",
+        r"\bagenda includes a public forum\b",
+        r"\bpublic forum for community input\b",
+        r"\bchanges? to the agenda will be addressed\b",
+        r"\bitems under study will be discussed\b",
+        r"\bstaff emergency items? will be addressed\b",
     ]
 ]
 
@@ -118,9 +123,13 @@ def _is_metadata_duplicate_bullet(text: str, meeting: Dict[str, Any]) -> bool:
     return not bool(substantive)
 
 
-def _clean_summary_bullets(bullets: List[str], meeting: Dict[str, Any], max_bullets: int = MAX_BULLETS) -> List[str]:
-    cleaned: List[str] = []
+def _partition_summary_bullets(
+    bullets: List[str], meeting: Dict[str, Any], max_bullets: int = MAX_BULLETS
+) -> Tuple[List[str], List[str]]:
+    kept: List[str] = []
+    filtered_routine: List[str] = []
     seen = set()
+
     for raw in bullets:
         b = _strip_leading_bullet(raw)
         if not b:
@@ -129,19 +138,22 @@ def _clean_summary_bullets(bullets: List[str], meeting: Dict[str, Any], max_bull
         key = re.sub(r"\s+", " ", b).strip().lower()
         if key in seen:
             continue
-
-        if _is_boilerplate_bullet(b):
-            continue
-
-        if _is_metadata_duplicate_bullet(b, meeting):
-            continue
-
         seen.add(key)
-        cleaned.append(b)
-        if len(cleaned) >= max_bullets:
+
+        if _is_boilerplate_bullet(b) or _is_metadata_duplicate_bullet(b, meeting):
+            filtered_routine.append(b)
+            continue
+
+        kept.append(b)
+        if len(kept) >= max_bullets:
             break
 
-    return cleaned
+    return kept, filtered_routine
+
+
+def _clean_summary_bullets(bullets: List[str], meeting: Dict[str, Any], max_bullets: int = MAX_BULLETS) -> List[str]:
+    kept, _ = _partition_summary_bullets(bullets, meeting, max_bullets=max_bullets)
+    return kept
 
 # ---------------------------
 # PDF text extraction (prefer project helper if present)
@@ -208,7 +220,11 @@ def llm_summarize(text: str, model: str = SUMMARIZER_MODEL, max_bullets: int = M
         from openai import OpenAI  # type: ignore
         client = OpenAI(api_key=api_key)
         prompt = textwrap.dedent(f"""
-        You are a city agenda summarizer. Read the following agenda text and extract the most notable items.
+        You are a city agenda summarizer for journalists. Extract only high-signal, newsworthy items.
+        Prioritize: ordinances/resolutions, contracts/procurements, budget/funding changes, zoning/land-use,
+        public hearings, litigation, appointments with impact, and policy changes.
+        Exclude routine procedural boilerplate such as: call to order, pledge, approval of minutes,
+        public comment instructions, meeting logistics/broadcast notes, and generic agenda housekeeping.
         Return up to {max_bullets} concise bullet points, each a single sentence.
 
         Agenda:
@@ -372,13 +388,16 @@ def main(argv: Optional[List[str]] = None) -> int:
 
         # merge cleaned bullets back into meetings.json for BOTH 'text' and 'pdf'
         if res.ok and res.bullets and res.used_kind in {"text", "pdf"}:
-            cleaned = _clean_summary_bullets(res.bullets, m, max_bullets=MAX_BULLETS)
+            cleaned, routine = _partition_summary_bullets(res.bullets, m, max_bullets=MAX_BULLETS)
             m["agenda_summary"] = cleaned
+            m["agenda_summary_routine"] = routine
             m["agenda_summary_source"] = res.used_kind
             m["agenda_summary_chars"] = res.chars
             merged += 1
             if DEBUG:
-                _log(f"✓ {slug}: merged {len(cleaned)}/{len(res.bullets)} bullets ({res.used_kind})")
+                _log(
+                    f"✓ {slug}: merged {len(cleaned)}/{len(res.bullets)} bullets ({res.used_kind}); routine_filtered={len(routine)}"
+                )
         else:
             if DEBUG:
                 _log(f"✗ {slug}: {res.reason}")

--- a/tests/test_summarize_filters.py
+++ b/tests/test_summarize_filters.py
@@ -1,6 +1,6 @@
 import unittest
 
-from scraper.summarize import _clean_summary_bullets
+from scraper.summarize import _clean_summary_bullets, _partition_summary_bullets
 
 
 class TestSummaryFiltering(unittest.TestCase):
@@ -48,6 +48,28 @@ class TestSummaryFiltering(unittest.TestCase):
         out = _clean_summary_bullets(bullets, meeting, max_bullets=10)
         self.assertIn("An executive session is scheduled to discuss confidential matters.", out)
         self.assertIn("The case discussed in executive session is Smith v. City, Case No. 2026CV12345.", out)
+
+    def test_drops_new_routine_patterns(self):
+        meeting = {"date": "2026-03-10", "start_time_local": "6:00 PM", "location": "City Hall"}
+        bullets = [
+            "The agenda includes a public forum for community input.",
+            "Changes to the agenda will be addressed at the beginning of the meeting.",
+            "Items under study will be discussed during the meeting.",
+            "Staff emergency items will be addressed at the start of the meeting.",
+            "A contract amendment for road reconstruction will be considered.",
+        ]
+        out = _clean_summary_bullets(bullets, meeting, max_bullets=10)
+        self.assertEqual(out, ["A contract amendment for road reconstruction will be considered."])
+
+    def test_partition_returns_routine_bucket(self):
+        meeting = {"date": "2026-03-10", "start_time_local": "6:00 PM", "location": "City Hall"}
+        bullets = [
+            "Public Comments",
+            "A resolution to approve a housing grant will be considered.",
+        ]
+        kept, routine = _partition_summary_bullets(bullets, meeting, max_bullets=10)
+        self.assertEqual(kept, ["A resolution to approve a housing grant will be considered."])
+        self.assertEqual(routine, ["Public Comments"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up for issue #2.

## Changes
- Added more routine/noise filters:
  - public forum/community input boilerplate
  - agenda-change housekeeping bullets
  - items-under-study housekeeping bullets
  - staff-emergency housekeeping bullets
- Improved LLM summarization prompt to prioritize journalist-relevant items and de-prioritize procedural boilerplate.
- Added bullet partitioning:
  - `agenda_summary` = kept/news-focused bullets
  - `agenda_summary_routine` = filtered routine bullets
- Added UI toggle on site (`Show routine items`) to reveal routine bullets on demand.

## Tests
- Updated/expanded unit tests in `tests/test_summarize_filters.py`
- Local run: `python -m unittest tests/test_summarize_filters.py` -> OK (6 tests)

Refs #2