### PR TITLE
fix(summary): reduce routine false positives from short location metadata

### DIFF
--- a/scraper/summarize.py
+++ b/scraper/summarize.py
@@ -105,10 +105,15 @@ def _is_metadata_duplicate_bullet(text: str, meeting: Dict[str, Any]) -> bool:
     time = str(meeting.get("start_time_local") or meeting.get("start_time") or meeting.get("time") or "").strip().lower()
     location = str(meeting.get("location") or "").strip().lower()
 
+    # Avoid false positives from very short location strings (e.g., "Ce").
+    location_match = False
+    if location and len(location) >= 4:
+        location_match = location in t
+
     looks_like_metadata = (
         (date and date in t)
         or (time and time in t)
-        or (location and location in t)
+        or location_match
         or bool(re.search(r"\b(meeting (will )?be held|located at|at \d{1,2}:\d{2})\b", t))
     )
 

--- a/tests/test_summarize_filters.py
+++ b/tests/test_summarize_filters.py
@@ -71,6 +71,15 @@ class TestSummaryFiltering(unittest.TestCase):
         self.assertEqual(kept, ["A resolution to approve a housing grant will be considered."])
         self.assertEqual(routine, ["Public Comments"])
 
+    def test_short_location_does_not_trigger_metadata_false_positive(self):
+        meeting = {"date": "2026-03-10", "start_time_local": "9:00 AM", "location": "Ce"}
+        bullets = [
+            "Approval of a Purchase Order to Tyler Technologies for annual maintenance totaling $150,623.42.",
+        ]
+        kept, routine = _partition_summary_bullets(bullets, meeting, max_bullets=10)
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(routine, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up quality fix after routine-toggle deployment.

## Problem
Some substantive bullets were incorrectly moved into `agenda_summary_routine` due to metadata duplicate detection using very short location values (e.g., `"Ce"`).

## Fix
- Metadata duplicate detection now only applies location substring matching when location length is >= 4.
- Added regression test to ensure short location values do not cause false positives.

## Validation
- `python -m unittest tests/test_summarize_filters.py` -> OK (7 tests)

Refs #2