### PR TITLE
feat(ui): Phase B controls bar responsiveness + accessibility focus

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -217,7 +217,7 @@ jobs:
           parts = []
           parts.append('<!doctype html><meta charset="utf-8"><title>MeetingWatch</title>')
           parts.append('''<style>
-            :root{--bg:#f8fafc;--card:#fff;--text:#0f172a;--muted:#475569;--line:#e2e8f0;--accent:#0b62d6;}
+            :root{--bg:#f8fafc;--card:#fff;--text:#0f172a;--muted:#475569;--line:#e2e8f0;--accent:#0b62d6;--focus:#1d4ed8;}
             body{font:16px/1.5 system-ui,Segoe UI,Helvetica,Arial;max-width:980px;margin:2rem auto;padding:0 1rem;background:var(--bg);color:var(--text);}
             h1{margin:0 0 .75rem;font-size:1.8rem;letter-spacing:-.01em;}
             .m{border:1px solid var(--line);background:var(--card);border-radius:14px;padding:16px;margin:0;box-shadow:0 1px 2px rgba(15,23,42,.04);}
@@ -226,9 +226,17 @@ jobs:
             li{margin:.28rem 0;max-width:72ch}
             a{color:var(--accent);text-decoration:none}
             a:hover{text-decoration:underline}
-            #controls{display:grid;gap:.75rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:1rem 0 1.25rem;position:sticky;top:0;background:var(--bg);padding:.5rem 0;z-index:5;}
+            a:focus-visible, select:focus-visible, input:focus-visible{outline:3px solid var(--focus);outline-offset:2px;border-radius:.35rem}
+            #controls{display:grid;gap:.75rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin:1rem 0 1.25rem;background:var(--bg);padding:.5rem .75rem;border:1px solid var(--line);border-radius:12px;}
             #controls label select{width:100%;padding:.5rem .6rem;border-radius:.6rem;border:1px solid var(--line);background:#fff}
             #results{list-style:none;padding:0;display:grid;gap:.9rem;}
+            @media (min-width: 900px){
+              #controls{position:sticky;top:0;z-index:5;box-shadow:0 1px 0 rgba(15,23,42,.03)}
+            }
+            @media (max-width: 640px){
+              body{margin:1rem auto;padding:0 .75rem}
+              #controls{grid-template-columns:1fr;padding:.6rem}
+            }
           </style>''')
           
           parts.append('<h1>MeetingWatch</h1>')


### PR DESCRIPTION
Follow-up for Issue #10 (Phase B layout usability).

Changes:
- Make sticky controls desktop-only (>=900px)
- Add bordered controls container for clearer separation
- Improve mobile spacing and force single-column controls under 640px
- Add visible keyboard focus styles for links/select/input

No data pipeline logic changes.