### PR TITLE
feat(attachments): show AgendaSuite supporting documents in meeting cards

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -289,6 +289,17 @@ jobs:
                   for b in bullets:
                       parts.append(f'<li>{b}</li>')
                   parts.append('</ul>')
+
+              docs = m.get('supporting_documents') or []
+              if isinstance(docs, list) and docs:
+                  parts.append('<div class="meta" style="margin-top:.45rem"><strong>Supporting documents</strong></div>')
+                  parts.append('<ul>')
+                  for d in docs:
+                      if isinstance(d, dict) and d.get('url'):
+                          t = html.escape(str(d.get('title') or 'Document'))
+                          u = html.escape(str(d.get('url')))
+                          parts.append(f'<li><a href="{u}" target="_blank" rel="noopener">{t}</a></li>')
+                  parts.append('</ul>')
               parts.append('</div>')
           
           parts.append('</div>')  # /#static-list
@@ -386,15 +397,26 @@ jobs:
               const when = (function(w){ return w ? '🕒 ' + w : ''; })(formatWhen(m));
               return [city, agenda, source, type, when].filter(Boolean).join('  •  ');
             }
+            function supportingDocsHTML(m){
+              const docs = Array.isArray(m.supporting_documents) ? m.supporting_documents : [];
+              if (!docs.length) return '';
+              const links = docs
+                .filter(d => d && d.url)
+                .map(d => '<li><a href="'+d.url+'" target="_blank" rel="noopener">'+(d.title || 'Document')+'</a></li>')
+                .join('');
+              if (!links) return '';
+              return '<div class="meta" style="margin-top:.45rem"><strong>Supporting documents</strong></div><ul>'+links+'</ul>';
+            }
             function bulletsHTML(m, showRoutine){
               const keep = Array.isArray(m.agenda_summary) ? m.agenda_summary
                          : (typeof m.agenda_summary === 'string' ? m.agenda_summary.split(/\\n+/).filter(Boolean) : []);
               const routine = Array.isArray(m.agenda_summary_routine) ? m.agenda_summary_routine
                             : (typeof m.agenda_summary_routine === 'string' ? m.agenda_summary_routine.split(/\\n+/).filter(Boolean) : []);
               const keepHtml = keep.length ? '<ul>' + keep.map(b => '<li>'+b+'</li>').join('') + '</ul>' : '';
-              if (!showRoutine || !routine.length) return keepHtml;
+              const docsHtml = supportingDocsHTML(m);
+              if (!showRoutine || !routine.length) return keepHtml + docsHtml;
               const routineHtml = '<details style="margin-top:.4rem"><summary style="cursor:pointer;color:#666">Routine items ('+routine.length+')</summary><ul style="color:#666">' + routine.map(b => '<li>'+b+'</li>').join('') + '</ul></details>';
-              return keepHtml + routineHtml;
+              return keepHtml + routineHtml + docsHtml;
             }
             function syncState(){
               const c = citySel.value, s = srcSel.value, showRoutine = routineToggle.checked;

--- a/scraper/epc_agendasuite.py
+++ b/scraper/epc_agendasuite.py
@@ -101,6 +101,37 @@ def _find_agenda_href(soup: BeautifulSoup) -> Optional[str]:
     return None
 
 
+def _extract_supporting_documents(soup: BeautifulSoup, agenda_href: Optional[str]) -> List[Dict[str, str]]:
+    docs: List[Dict[str, str]] = []
+    seen = set()
+    agenda_abs = urljoin(BASE, agenda_href) if agenda_href else ''
+
+    for tr in soup.select("table tr"):
+        a = tr.find("a", href=True)
+        if not a:
+            continue
+        href = a.get("href") or ""
+        if "/file/getfile/" not in href:
+            continue
+        abs_url = urljoin(BASE, href)
+        if abs_url == agenda_abs:
+            continue
+
+        row_text = _text(tr)
+        if re.search(r"\bagenda\b", row_text, re.I):
+            continue
+
+        title = _text(a) or row_text or "Supporting document"
+        title = re.sub(r"\s+", " ", title).strip(" -:\t")[:140]
+        key = (title.lower(), abs_url)
+        if key in seen:
+            continue
+        seen.add(key)
+        docs.append({"title": title, "url": abs_url})
+
+    return docs
+
+
 def _meeting_title_from_detail(soup: BeautifulSoup) -> Optional[str]:
     # Try to use the big heading line that contains "Board of County Commissioners"
     # (and avoid "Work Session" variants).
@@ -128,11 +159,13 @@ def _extract_detail_info(detail_url: str) -> Dict[str, Optional[str]]:
     agenda_url = _find_agenda_href(soup)
     location = _find_location(soup)
     title = _meeting_title_from_detail(soup)
+    supporting_documents = _extract_supporting_documents(soup, agenda_url)
 
     return {
         "agenda_url": agenda_url,
         "location": location,
         "title": title,
+        "supporting_documents": supporting_documents,
     }
 
 
@@ -216,7 +249,8 @@ def parse_epc() -> List[Dict]:
                 summary = summarize_pdf_if_any(m["agenda_url"])
                 if summary:
                     m["agenda_summary"] = summary
-
+            if info.get("supporting_documents"):
+                m["supporting_documents"] = info["supporting_documents"]
 
             # Provide a consistent Mountain Time zone for downstream rendering if your pipeline uses it.
             m["tz"] = "America/Denver"


### PR DESCRIPTION
Progress on #4.

What this adds:
- Extract supporting document links from AgendaSuite detail pages (excluding primary agenda link).
- Store them in `supporting_documents` on meetings.
- Render supporting document links under agenda bullets in both static fallback and dynamic JS card rendering.

Scope notes:
- First pass targets AgendaSuite entries (El Paso County) to establish data contract + UI rendering.
- No destructive workflow changes.