### PR TITLE
test(ranking): add scoring behavior tests and rollback toggle

### DIFF
--- a/scraper/summarize.py
+++ b/scraper/summarize.py
@@ -39,6 +39,8 @@ try:
 except Exception:
     CITY_SUMMARY_TERM_OVERRIDES = {}
 
+ENABLE_RELEVANCE_SCORING = os.getenv("ENABLE_RELEVANCE_SCORING", "1") == "1"
+
 
 def _city_term_override(city: str) -> Tuple[List[str], List[str]]:
     cfg = CITY_SUMMARY_TERM_OVERRIDES.get(city) if isinstance(CITY_SUMMARY_TERM_OVERRIDES, dict) else None
@@ -212,7 +214,10 @@ def _partition_summary_bullets(
             score += 10
         kept_candidates.append((score, i, b))
 
-    kept_candidates.sort(key=lambda t: (-t[0], t[1]))
+    if ENABLE_RELEVANCE_SCORING:
+        kept_candidates.sort(key=lambda t: (-t[0], t[1]))
+    else:
+        kept_candidates.sort(key=lambda t: t[1])
     kept = [b for _, _, b in kept_candidates[:max_bullets]]
     return kept, filtered_routine
 

--- a/tests/test_summarize_filters.py
+++ b/tests/test_summarize_filters.py
@@ -1,5 +1,6 @@
 import unittest
 
+import scraper.summarize as summarize
 from scraper.summarize import _clean_summary_bullets, _partition_summary_bullets
 
 
@@ -79,6 +80,34 @@ class TestSummaryFiltering(unittest.TestCase):
         kept, routine = _partition_summary_bullets(bullets, meeting, max_bullets=10)
         self.assertEqual(len(kept), 1)
         self.assertEqual(routine, [])
+
+    def test_relevance_scoring_prioritizes_high_signal_when_truncated(self):
+        meeting = {"date": "2026-03-10", "start_time_local": "6:00 PM", "location": "City Hall"}
+        bullets = [
+            "General announcements and recognitions.",
+            "Approve ordinance for downtown zoning amendment and budget appropriation.",
+        ]
+        prev = summarize.ENABLE_RELEVANCE_SCORING
+        summarize.ENABLE_RELEVANCE_SCORING = True
+        try:
+            kept, _ = _partition_summary_bullets(bullets, meeting, max_bullets=1)
+        finally:
+            summarize.ENABLE_RELEVANCE_SCORING = prev
+        self.assertEqual(kept, ["Approve ordinance for downtown zoning amendment and budget appropriation."])
+
+    def test_rollback_toggle_preserves_input_order(self):
+        meeting = {"date": "2026-03-10", "start_time_local": "6:00 PM", "location": "City Hall"}
+        bullets = [
+            "General announcements and recognitions.",
+            "Approve ordinance for downtown zoning amendment and budget appropriation.",
+        ]
+        prev = summarize.ENABLE_RELEVANCE_SCORING
+        summarize.ENABLE_RELEVANCE_SCORING = False
+        try:
+            kept, _ = _partition_summary_bullets(bullets, meeting, max_bullets=1)
+        finally:
+            summarize.ENABLE_RELEVANCE_SCORING = prev
+        self.assertEqual(kept, ["General announcements and recognitions."])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Progress on #3.

Adds:
- rollback toggle `ENABLE_RELEVANCE_SCORING` (env-controlled; default on)
- tests for ranking behavior when truncating bullets
- tests verifying rollback path preserves original order

Validation:
- Syntax check passed (`py_compile`).
- Local unittest run blocked due missing runtime dependency (`requests`) in this environment; CI will validate in workflow runtime.