### PR TITLE
feat(onboarding): add city config schema, validator, and dry-run checks

### DIFF
--- a/config/cities.example.json
+++ b/config/cities.example.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "cities": [
+    {
+      "city": "Example County",
+      "platform": "agendasuite",
+      "timezone": "America/Denver",
+      "source_url": "https://example.com",
+      "parser_template": "agendasuite",
+      "enabled": false,
+      "approval_ticket": "APPROVE: city-example-county"
+    }
+  ]
+}

--- a/docs/CITY_ONBOARDING.md
+++ b/docs/CITY_ONBOARDING.md
@@ -1,0 +1,50 @@
+# City Onboarding (Config-First)
+
+Issue: #5 (Self-serve city onboarding)
+
+## Goal
+Add new cities through configuration for supported platform templates without immediate scraper code edits.
+
+## Supported templates
+- `agendasuite`
+- `civicclerk`
+
+## Config file
+Start from:
+- `config/cities.example.json`
+
+Required fields per city:
+- `city` (string)
+- `platform` (`agendasuite|civicclerk`)
+- `timezone` (must be `America/*`)
+- `source_url` (http/https URL)
+- `parser_template` (`agendasuite|civicclerk`)
+- `enabled` (boolean)
+
+Approval-gate field:
+- `approval_ticket` (required when `enabled=true`)
+
+## Validation
+```bash
+python scripts/onboarding_validate.py --config config/cities.example.json
+```
+
+## Dry-run (non-production)
+```bash
+python scripts/onboarding_validate.py --config config/cities.example.json --dry-run
+```
+
+Dry-run only verifies source URL reachability/content type. It does not modify production data.
+
+## Production enable flow
+1. Add city config with `enabled: false`
+2. Run validator + dry-run and collect output
+3. Obtain explicit approval ticket (e.g. `APPROVE: city-<name>`)
+4. Set `enabled: true` and include `approval_ticket`
+5. Merge + monitor next scheduled run
+
+## Rollback
+If a city causes bad output:
+1. Set `enabled: false`
+2. Re-run validator to confirm config integrity
+3. Merge rollback and monitor next run

--- a/scripts/onboarding_validate.py
+++ b/scripts/onboarding_validate.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+import subprocess
+from urllib.parse import urlparse
+
+ALLOWED_PLATFORMS = {"agendasuite", "civicclerk"}
+ALLOWED_TEMPLATES = {"agendasuite", "civicclerk"}
+
+
+def err(msg, errs):
+    errs.append(msg)
+
+
+def valid_tz(tz: str) -> bool:
+    return isinstance(tz, str) and tz.startswith("America/")
+
+
+def valid_url(u: str) -> bool:
+    try:
+        p = urlparse(u)
+        return p.scheme in ("http", "https") and bool(p.netloc)
+    except Exception:
+        return False
+
+
+def dry_fetch(url: str, timeout=15):
+    # Use curl here for consistency with CI/runtime environments where
+    # python ssl cert stores can differ.
+    cmd = [
+        "curl",
+        "-sS",
+        "-I",
+        "--max-time",
+        str(timeout),
+        "-A",
+        "MeetingWatch-Onboarding-Validator/1.0",
+        url,
+    ]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(p.stderr.strip() or "curl failed")
+
+    status = 0
+    ctype = ""
+    for line in (p.stdout or "").splitlines():
+        l = line.strip()
+        if l.startswith("HTTP/"):
+            parts = l.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                status = int(parts[1])
+        if l.lower().startswith("content-type:"):
+            ctype = l.split(":", 1)[1].strip()
+    return status or 200, ctype
+
+
+def validate_city(c):
+    errors = []
+    required = ["city", "platform", "timezone", "source_url", "parser_template", "enabled"]
+    for k in required:
+        if k not in c:
+            err(f"missing required field: {k}", errors)
+
+    if c.get("platform") not in ALLOWED_PLATFORMS:
+        err(f"platform must be one of {sorted(ALLOWED_PLATFORMS)}", errors)
+    if c.get("parser_template") not in ALLOWED_TEMPLATES:
+        err(f"parser_template must be one of {sorted(ALLOWED_TEMPLATES)}", errors)
+    if c.get("platform") and c.get("parser_template") and c.get("platform") != c.get("parser_template"):
+        err("platform and parser_template should match for template onboarding", errors)
+    if not valid_tz(c.get("timezone", "")):
+        err("timezone must be an America/* zone", errors)
+    if not valid_url(c.get("source_url", "")):
+        err("source_url must be a valid http(s) URL", errors)
+
+    # approval gate: enabled city requires explicit approval ticket string
+    if c.get("enabled") is True and not str(c.get("approval_ticket", "")).strip():
+        err("enabled=true requires non-empty approval_ticket", errors)
+
+    return errors
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Validate MeetingWatch city onboarding config")
+    ap.add_argument("--config", default="config/cities.example.json")
+    ap.add_argument("--dry-run", action="store_true", help="Fetch source_url to verify reachability")
+    args = ap.parse_args()
+
+    try:
+        with open(args.config, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except Exception as e:
+        print(json.dumps({"ok": False, "error": f"failed to load config: {e}"}))
+        return 2
+
+    cities = payload.get("cities", [])
+    if not isinstance(cities, list) or not cities:
+        print(json.dumps({"ok": False, "error": "cities must be a non-empty array"}))
+        return 2
+
+    results = []
+    all_ok = True
+    for c in cities:
+        city_name = c.get("city", "<unknown>")
+        errors = validate_city(c)
+        dry = None
+        if args.dry_run and not errors:
+            try:
+                status, ctype = dry_fetch(c["source_url"])
+                dry = {"status": status, "content_type": ctype}
+                if status >= 400:
+                    errors.append(f"dry-run fetch returned HTTP {status}")
+            except Exception as e:
+                errors.append(f"dry-run fetch failed: {e}")
+        ok = len(errors) == 0
+        if not ok:
+            all_ok = False
+        results.append({"city": city_name, "ok": ok, "errors": errors, "dry_run": dry})
+
+    out = {"ok": all_ok, "results": results}
+    print(json.dumps(out, indent=2))
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_onboarding_validator.py
+++ b/tests/test_onboarding_validator.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def run_validator(tmp_path, payload, dry=False):
+    cfg = tmp_path / "cities.json"
+    cfg.write_text(json.dumps(payload), encoding="utf-8")
+    cmd = ["python3", "scripts/onboarding_validate.py", "--config", str(cfg)]
+    if dry:
+        cmd.append("--dry-run")
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, p.stdout
+
+
+def test_valid_config_passes(tmp_path):
+    payload = {
+        "version": 1,
+        "cities": [
+            {
+                "city": "Test City",
+                "platform": "agendasuite",
+                "timezone": "America/Denver",
+                "source_url": "https://example.com",
+                "parser_template": "agendasuite",
+                "enabled": False,
+            }
+        ],
+    }
+    code, out = run_validator(tmp_path, payload)
+    assert code == 0
+    assert '"ok": true' in out.lower()
+
+
+def test_enabled_requires_approval_ticket(tmp_path):
+    payload = {
+        "version": 1,
+        "cities": [
+            {
+                "city": "Test City",
+                "platform": "civicclerk",
+                "timezone": "America/Denver",
+                "source_url": "https://example.com",
+                "parser_template": "civicclerk",
+                "enabled": True,
+            }
+        ],
+    }
+    code, out = run_validator(tmp_path, payload)
+    assert code == 1
+    assert "approval_ticket" in out


### PR DESCRIPTION
Progress on #5.

Adds config-first onboarding foundation:
- `config/cities.example.json` schema template
- `scripts/onboarding_validate.py` for schema validation + actionable errors
- `--dry-run` URL fetch checks (non-production)
- approval gate rule: `enabled=true` requires `approval_ticket`
- docs: `docs/CITY_ONBOARDING.md` (enable + rollback flow)
- tests: `tests/test_onboarding_validator.py`

Validation run:
- `python scripts/onboarding_validate.py --config config/cities.example.json` => ok
- `python scripts/onboarding_validate.py --config config/cities.example.json --dry-run` => ok