### PR TITLE
fix(agenda-ux): prefer browser-view agenda links for CivicClerk streams

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -269,8 +269,8 @@ jobs:
               # keep your previous time fallbacks
               time  = html.escape(m.get('start_time_local') or m.get('start_time') or m.get('time') or '')
               loc   = html.escape(m.get('location') or '')
-              agenda_url = m.get('agenda_url') or m.get('agenda_pdf') or ''
-              agenda_link = f' &middot; <a href="{html.escape(agenda_url)}">agenda</a>' if agenda_url else ''
+              agenda_url = m.get('agenda_view_url') or m.get('agenda_url') or m.get('agenda_pdf') or ''
+              agenda_link = f' &middot; <a href="{html.escape(agenda_url)}" target="_blank" rel="noopener">agenda</a>' if agenda_url else ''
               source_url = m.get('source') or ''
               source_link = f' &middot; <a href="{html.escape(source_url)}">{html.escape(source_url)}</a>' if source_url else ''
           
@@ -391,7 +391,8 @@ jobs:
             }
             function headerLine(m){
               const city = m.city ? '🏙️ ' + m.city : '';
-              const agenda = (m.agenda_url || m.agenda_pdf) ? '<a href="'+(m.agenda_url||m.agenda_pdf)+'" target="_blank" rel="noopener">📝 Agenda</a>' : '';
+              const agendaHref = (m.agenda_view_url || m.agenda_url || m.agenda_pdf || '');
+              const agenda = agendaHref ? '<a href="'+agendaHref+'" target="_blank" rel="noopener">📝 Agenda</a>' : '';
               const source = m.source ? '<a href="'+m.source+'" target="_blank" rel="noopener">🌐 Source</a>' : '';
               const type = '📌 ' + (m.meeting_type || inferType(m.title||''));
               const when = (function(w){ return w ? '🕒 ' + w : ''; })(formatWhen(m));

--- a/scraper/pueblo_civicclerk.py
+++ b/scraper/pueblo_civicclerk.py
@@ -693,6 +693,9 @@ def parse_pueblo() -> List[Dict]:
         pdf, txt, supporting_docs = find_agenda_assets(u)
         if pdf:
             m["agenda_url"] = pdf
+            # UX: CivicClerk stream URLs may force download; prefer opening meeting page in browser tab.
+            if "GetMeetingFileStream" in pdf and u:
+                m["agenda_view_url"] = u
             summary = summarize_pdf_if_any(pdf)
             if summary:
                 m["agenda_summary"] = summary


### PR DESCRIPTION
Progress on #27.

Changes:
- For CivicClerk stream-generated agenda URLs (`GetMeetingFileStream`), set `agenda_view_url` to the meeting page URL for browser-friendly opening.
- UI now prefers `agenda_view_url` over direct `agenda_url` for Agenda action links (static + dynamic rendering).

Expected behavior:
- Pueblo Agenda click opens meeting page in a browser tab (deterministic fallback) instead of immediately forcing a file download.