### PR TITLE
fix(agenda-ux): parse stream fileId correctly for CivicClerk deep links

### DIFF
--- a/scraper/pueblo_civicclerk.py
+++ b/scraper/pueblo_civicclerk.py
@@ -146,6 +146,11 @@ def _meeting_id_from_event_url(u: str) -> Optional[str]:
 def _stream_fileid_from_url(u: str) -> Optional[str]:
     if not u:
         return None
+    # API stream format: GetMeetingFileStream(fileId=5957,plainText=false)
+    m = STREAM_FILEID_RE.search(u)
+    if m:
+        return m.group(1)
+    # Query-string fallback: ...?fileId=5957
     m = STREAM_FILEID_QS_RE.search(u)
     return m.group(1) if m else None
 


### PR DESCRIPTION
Follow-up for #27 regression.

Bug:
- Deep-link builder only parsed query-style `fileId`, so stream URLs like `GetMeetingFileStream(fileId=5957,plainText=false)` fell back to `/overview/files`.

Fix:
- `_stream_fileid_from_url` now parses both stream-format and query-format fileId values.

Expected result:
- Pueblo agenda links resolve to `/event/<id>/files/agenda/<fileId>` when available.