### PR TITLE
Fix El Paso card header normalization for BOCC meetings

### DIFF
--- a/scraper/epc_agendasuite.py
+++ b/scraper/epc_agendasuite.py
@@ -141,11 +141,17 @@ def _meeting_title_from_detail(soup: BeautifulSoup) -> Optional[str]:
         if ALLOW_TITLE_RE.search(t):
             texts.append(t)
     if texts:
-        # Prefer the shortest that still contains the phrase (usually "Board of County Commissioners" or "... Meeting")
+        # Prefer the shortest that still contains the phrase.
         texts.sort(key=len)
         t = texts[0]
         # Drop 'Work Session' etc if present.
         t = BLOCK_TITLE_RE.sub("", t).strip(" -—:")
+
+        # AgendaSuite detail pages can include header boilerplate in the same text node,
+        # e.g. "Board of County Commissioners Held at: ... Tuesday ... From ...".
+        # To keep cross-city cards consistent, normalize El Paso to a concise meeting type.
+        if ALLOW_TITLE_RE.search(t):
+            return "Board of County Commissioners"
         return t[:150]
 
     # Fallback


### PR DESCRIPTION
## Summary
This PR normalizes El Paso AgendaSuite meeting headers so the `📌` chip stays concise and consistent with other city cards.

- Forces BOCC meeting type to `Board of County Commissioners` when detected in detail-page title text.
- Prevents header pollution from concatenated boilerplate like `Held at`, day/date, and time ranges.

## Why
Fixes #32.

## Scope
- `scraper/epc_agendasuite.py` only

## Validation
- Static code inspection confirms `meeting_type` now resolves to concise BOCC value for El Paso items.
- Existing non-El Paso parsers untouched.