### PR TITLE
Fix Colorado Springs meeting card header type labels (Issue #41)

### DIFF
--- a/scraper/coloradosprings_legistar.py
+++ b/scraper/coloradosprings_legistar.py
@@ -143,6 +143,29 @@ def _time_from_agenda_pdf(url: str, session: requests.Session) -> Optional[str]:
 def _is_wanted(body: str, mtg_type: str) -> bool:
     return "council" in (body or "").lower() or "council" in (mtg_type or "").lower()
 
+
+def _normalize_cs_meeting_type(ev: Dict) -> str:
+    """
+    Normalize Colorado Springs card meeting type to a stable user-facing label.
+
+    We only emit one of:
+      - "City Council Meeting"
+      - "City Council Work Session"
+
+    NOTE: Legistar's EventAgendaStatusName can be values like "Final" and should
+    never be used as the meeting type label.
+    """
+    candidates = [
+        ev.get("EventMeetingTypeName"),
+        ev.get("EventMeetingType"),
+        ev.get("EventTitle"),
+        ev.get("EventBodyName"),
+    ]
+    text = " ".join((c or "").strip() for c in candidates if c).lower()
+    if "work session" in text:
+        return "City Council Work Session"
+    return "City Council Meeting"
+
 # Boilerplate/headers we don't want as bullets
 _DROP_PATTERNS = [
     r"^city of colorado springs\b",
@@ -248,14 +271,14 @@ def parse_legistar() -> List[Dict]:
     meetings: List[Dict] = []
     for ev in items:
         body = (ev.get("EventBodyName") or "").strip()
-        mtg_type = (
+        mtg_type_raw = (
             ev.get("EventMeetingTypeName")
             or ev.get("EventMeetingType")
-            or ev.get("EventAgendaStatusName")
             or ""
         ).strip()
+        mtg_type = _normalize_cs_meeting_type(ev)
 
-        if not _is_wanted(body, mtg_type):
+        if not _is_wanted(body, mtg_type_raw):
             continue
 
         date_str = (ev.get("EventDate") or "").split("T")[0]
@@ -299,7 +322,7 @@ def parse_legistar() -> List[Dict]:
         meetings.append(
             make_meeting(
                 city_or_body="Colorado Springs — City Council",
-                meeting_type=mtg_type or "City Council Meeting",
+                meeting_type=mtg_type,
                 date=date_str,
                 start_time_local=start_time_local,
                 status="Scheduled",

--- a/tests/test_coloradosprings_meeting_type.py
+++ b/tests/test_coloradosprings_meeting_type.py
@@ -1,0 +1,23 @@
+import unittest
+
+from scraper.coloradosprings_legistar import _normalize_cs_meeting_type
+
+
+class TestColoradoSpringsMeetingType(unittest.TestCase):
+    def test_work_session_detected_from_meeting_type_name(self):
+        ev = {
+            "EventMeetingTypeName": "City Council Work Session",
+            "EventAgendaStatusName": "Final",
+        }
+        self.assertEqual(_normalize_cs_meeting_type(ev), "City Council Work Session")
+
+    def test_regular_meeting_not_overridden_by_agenda_status(self):
+        ev = {
+            "EventMeetingTypeName": "City Council",
+            "EventAgendaStatusName": "Final",
+        }
+        self.assertEqual(_normalize_cs_meeting_type(ev), "City Council Meeting")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #41

## Summary
Colorado Springs cards were surfacing Legistar agenda status (e.g., `Final`) as the card meeting-type label.

This PR normalizes the label to a user-facing type so cards show either:
- `City Council Meeting`
- `City Council Work Session`

## Changes
- Added `_normalize_cs_meeting_type(ev)` in `scraper/coloradosprings_legistar.py`.
- Stopped using `EventAgendaStatusName` as meeting type fallback.
- Kept council filtering based on raw meeting-type fields.
- Added unit tests in `tests/test_coloradosprings_meeting_type.py` for:
  - work-session detection
  - protection against `Final` overriding the meeting type

## Validation
- `python -m unittest tests/test_coloradosprings_meeting_type.py -v` passes.
