### PR TITLE
chore(ci): workflow action upgrades for Node 24 readiness (Issue #47)

### DIFF
--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -12,7 +12,7 @@ jobs:
   tag-backup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Cron heartbeat
         run: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ github.event_name != 'schedule' || steps.guard.outputs.continue == 'true' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload data artifact (data/)
         if: ${{ github.event_name != 'schedule' || steps.guard.outputs.continue == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: scrape-data
           path: data/
@@ -163,10 +163,10 @@ jobs:
     if: ${{ github.event_name != 'schedule' || needs.scrape.outputs.should_run == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scrape data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: scrape-data
           path: ./data
@@ -536,7 +536,7 @@ jobs:
           find _site -maxdepth 3 -type f -print
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: _site
 

--- a/.github/workflows/validate-smoke.yml
+++ b/.github/workflows/validate-smoke.yml
@@ -57,7 +57,7 @@ jobs:
     if: ${{ always() && needs.smoke.result == 'failure' }}
     steps:
       - name: Create/append alert issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = '🚨 Smoke check failed (MeetingWatch)';


### PR DESCRIPTION
Closes #47

## Summary
Maintenance-only workflow action version updates to address GitHub Actions Node.js 20 deprecation warnings and align with Node 24-ready action releases.

## Exactly what changed
### `.github/workflows/site.yml`
- `actions/checkout@v4` → `actions/checkout@v6`
- `actions/setup-python@v5` → `actions/setup-python@v6`
- `actions/upload-artifact@v4` → `actions/upload-artifact@v7`
- `actions/download-artifact@v4` → `actions/download-artifact@v8`
- `actions/upload-pages-artifact@v3` → `actions/upload-pages-artifact@v4`
- `actions/deploy-pages@v4` unchanged (already current Node 24-ready major)

### `.github/workflows/daily-backup.yml`
- `actions/checkout@v4` → `actions/checkout@v6`

### `.github/workflows/validate-smoke.yml`
- `actions/github-script@v7` → `actions/github-script@v8`

## Why
These are runtime/dependency maintenance bumps only, intended to remove Node 20 deprecation annotations and keep workflows compatible with GitHub-hosted runner runtime changes.

## Impacted jobs/workflows
- `site.yml`: `scrape`, `build`, and Pages artifact/deploy steps
- `daily-backup.yml`: `tag-backup`
- `validate-smoke.yml`: `open-issue-on-failure`

## Risk notes
- Low risk: no workflow logic, triggers, conditions, scripts, or artifact names were changed.
- Potential compatibility consideration: self-hosted runners must meet minimum runner version requirements for newer Node 24-based actions. GitHub-hosted runners are expected to be compatible.
