### PR TITLE
Fix keyword emphasis visibility in meeting card bullets

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -225,8 +225,8 @@ jobs:
 
           def format_bullet_html(text):
               safe = html.escape(str(text or ""))
-              safe = _KEYWORD_RE.sub(lambda m: f"<strong>{m.group(0)}</strong>", safe)
-              safe = _MONEY_RE.sub(lambda m: f"<strong style=\"color:#15803d\">{m.group(0)}</strong>", safe)
+              safe = _KEYWORD_RE.sub(lambda m: f"<span class=\"kw-emph\">{m.group(0)}</span>", safe)
+              safe = _MONEY_RE.sub(lambda m: f"<span class=\"money-emph\">{m.group(0)}</span>", safe)
               return safe
 
           run_dt_utc = datetime.now(timezone.utc)
@@ -245,6 +245,8 @@ jobs:
             .meta{color:var(--muted);font-size:.9rem;line-height:1.4}
             .run-meta{margin:.25rem 0 .9rem;color:var(--muted);font-size:.92rem}
             .agenda-missing{color:#b91c1c;font-weight:600}
+            .kw-emph{font-weight:800;color:#0f172a}
+            .money-emph{font-weight:800;color:#15803d}
             ul{margin:.6rem 0 0 1.15rem;padding:0}
             li{margin:.28rem 0;max-width:72ch}
             a{color:var(--accent);text-decoration:none}
@@ -451,8 +453,8 @@ jobs:
             }
             function styleBulletText(text){
               let safe = escapeHtml(String(text || ''));
-              safe = safe.replace(/\b(ordnance|ordinance|resolution|appeal|amendment)s?\b/gi, '<strong>$&</strong>');
-              safe = safe.replace(/(?:US\$\s*)?\$\s?\d[\d,]*(?:\.\d{2})?(?:\s*(?:million|billion|thousand|m|bn|k))?/gi, '<strong style="color:#15803d">$&</strong>');
+              safe = safe.replace(/\b(ordnance|ordinance|resolution|appeal|amendment)s?\b/gi, '<span class="kw-emph">$&</span>');
+              safe = safe.replace(/(?:US\$\s*)?\$\s?\d[\d,]*(?:\.\d{2})?(?:\s*(?:million|billion|thousand|m|bn|k))?/gi, '<span class="money-emph">$&</span>');
               return safe;
             }
             function _normWords(s){


### PR DESCRIPTION
Closes #55

## Plan
1. Add explicit CSS emphasis classes for keyword and money highlights.
2. Update both Python static-render formatter and JS dynamic formatter to emit class-based spans.
3. Keep existing match patterns and behavior unchanged.

## Changes
- Added `.kw-emph` (`font-weight: 800`) for keywords.
- Added `.money-emph` (`font-weight: 800; color: #15803d`) for dollar amounts.
- Updated formatter wrappers in static and dynamic paths from ad-hoc `<strong>` to classed `<span>`.

## Review
- [x] Keyword emphasis now explicit and consistent.
- [x] Dollar emphasis preserved.
- [x] No filter/routine/docs behavior changes.