### PR TITLE
Fix canonical site references to jysc-curator Pages URL

### DIFF
--- a/.github/workflows/validate-smoke.yml
+++ b/.github/workflows/validate-smoke.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - name: Set target URLs
         run: |
-          echo "SITE_URL=https://human83.github.io/MeetingWatch/" >> $GITHUB_ENV
-          echo "JSON_URL=https://human83.github.io/MeetingWatch/data/meetings.json" >> $GITHUB_ENV
+          echo "SITE_URL=https://jysc-curator.github.io/MeetingWatch/" >> $GITHUB_ENV
+          echo "JSON_URL=https://jysc-curator.github.io/MeetingWatch/data/meetings.json" >> $GITHUB_ENV
 
       - name: Check homepage returns HTTP 200
         run: |

--- a/demo.html
+++ b/demo.html
@@ -336,7 +336,7 @@
         <span class="badge">LIVE+DEMO</span>
         <span id="modeNote">Colorado selected</span>
       </div>
-      <a class="btn small" href="https://human83.github.io/MeetingWatch/" title="Current production homepage">Current site</a>
+      <a class="btn small" href="https://jysc-curator.github.io/MeetingWatch/" title="Current production homepage">Current site</a>
       <a class="btn small" href="./data/meetings.json" title="Raw Colorado feed (meetings.json)">meetings.json</a>
       <button class="btn primary small" id="btnRefresh" type="button" title="Refresh live feed">Refresh</button>
     </div>


### PR DESCRIPTION
Closes #60

## Why
Recent UX fixes were deployed to `https://jysc-curator.github.io/MeetingWatch/`, but smoke checks and demo link still pointed to `https://human83.github.io/MeetingWatch/` (older site), causing false validation and confusion during review.

## Plan
1. Point post-deploy smoke checks at this repo's actual Pages URL.
2. Update demo "Current site" link to same canonical URL.
3. Keep all scraper/index behavior unchanged.

## Changes
- `.github/workflows/validate-smoke.yml`: update `SITE_URL` and `JSON_URL` to `jysc-curator.github.io/MeetingWatch`.
- `demo.html`: update "Current site" button href to `jysc-curator.github.io/MeetingWatch`.

## Verification
- `https://jysc-curator.github.io/MeetingWatch/` contains latest features (city title + keyword/dollar emphasis).
- `https://human83.github.io/MeetingWatch/` still shows older layout, confirming mismatch root cause.