### PR TITLE
Make keyword emphasis unmistakable with high-contrast highlight styling

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -245,7 +245,7 @@ jobs:
             .meta{color:var(--muted);font-size:.9rem;line-height:1.4}
             .run-meta{margin:.25rem 0 .9rem;color:var(--muted);font-size:.92rem}
             .agenda-missing{color:#b91c1c;font-weight:600}
-            .kw-emph{font-weight:800;color:#0f172a}
+            .kw-emph{font-weight:900;color:#111827;background:#fef08a;border-radius:.18em;padding:0 .14em;box-decoration-break:clone;-webkit-box-decoration-break:clone}
             .money-emph{font-weight:800;color:#15803d}
             ul{margin:.6rem 0 0 1.15rem;padding:0}
             li{margin:.28rem 0;max-width:72ch}


### PR DESCRIPTION
Closes #62

## Plan
1. Keep existing keyword match + wrappers intact.
2. Increase `.kw-emph` visual contrast so terms are immediately noticeable to users.
3. Preserve money emphasis and all behavior.

## Change
- Updated `.kw-emph` CSS in the site generator to use: `font-weight:900`, dark text, and subtle yellow highlight chip styling (`background`, `padding`, `border-radius`, `box-decoration-break`).

## Why
Prior bold-only styling was technically applied but not visually obvious enough in real browsing conditions.

## Validation
- Keywords remain wrapped and now render with high-contrast emphasis.
- Dollar formatting remains bold green via `.money-emph`.