### PR TITLE
Keep keyword emphasis after JS render via inline formatter styles

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -225,8 +225,8 @@ jobs:
 
           def format_bullet_html(text):
               safe = html.escape(str(text or ""))
-              safe = _KEYWORD_RE.sub(lambda m: f"<span class=\"kw-emph\">{m.group(0)}</span>", safe)
-              safe = _MONEY_RE.sub(lambda m: f"<span class=\"money-emph\">{m.group(0)}</span>", safe)
+              safe = _KEYWORD_RE.sub(lambda m: f"<strong style=\"font-weight:900 !important;background:#fef08a;color:#111827;border-radius:.18em;padding:0 .14em\">{m.group(0)}</strong>", safe)
+              safe = _MONEY_RE.sub(lambda m: f"<strong style=\"font-weight:800 !important;color:#15803d\">{m.group(0)}</strong>", safe)
               return safe
 
           run_dt_utc = datetime.now(timezone.utc)
@@ -453,8 +453,8 @@ jobs:
             }
             function styleBulletText(text){
               let safe = escapeHtml(String(text || ''));
-              safe = safe.replace(/\b(ordnance|ordinance|resolution|appeal|amendment)s?\b/gi, '<span class="kw-emph">$&</span>');
-              safe = safe.replace(/(?:US\$\s*)?\$\s?\d[\d,]*(?:\.\d{2})?(?:\s*(?:million|billion|thousand|m|bn|k))?/gi, '<span class="money-emph">$&</span>');
+              safe = safe.replace(/\b(ordnance|ordinance|resolution|appeal|amendment)s?\b/gi, '<strong style="font-weight:900 !important;background:#fef08a;color:#111827;border-radius:.18em;padding:0 .14em">$&</strong>');
+              safe = safe.replace(/(?:US\$\s*)?\$\s?\d[\d,]*(?:\.\d{2})?(?:\s*(?:million|billion|thousand|m|bn|k))?/gi, '<strong style="font-weight:800 !important;color:#15803d">$&</strong>');
               return safe;
             }
             function _normWords(s){


### PR DESCRIPTION
Closes #64

## Why
User-reported behavior indicates emphasis is visible in initial static render but appears to vanish after dynamic JS list render when results are present.

## Plan
1. Make formatter output self-styled for critical emphasis (keywords + money).
2. Apply the same approach in both static Python and dynamic JS formatting paths.
3. Keep matching terms/logic unchanged.

## Change
- Replaced class-only wrappers with inline `<strong style=...>` wrappers in both formatters:
  - Keywords: heavy bold + subtle yellow highlight
  - Money: bold green

## Outcome
Critical emphasis does not depend on class/style resolution and remains visible after dynamic rerender.