### PR TITLE
Fix dynamic keyword matching by escaping JS word boundaries in generator

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -453,7 +453,7 @@ jobs:
             }
             function styleBulletText(text){
               let safe = escapeHtml(String(text || ''));
-              safe = safe.replace(/\b(ordnance|ordinance|resolution|appeal|amendment)s?\b/gi, '<strong style="font-weight:900 !important;background:#fef08a;color:#111827;border-radius:.18em;padding:0 .14em">$&</strong>');
+              safe = safe.replace(/\\b(ordnance|ordinance|resolution|appeal|amendment)s?\\b/gi, '<strong style="font-weight:900 !important;background:#fef08a;color:#111827;border-radius:.18em;padding:0 .14em">$&</strong>');
               safe = safe.replace(/(?:US\$\s*)?\$\s?\d[\d,]*(?:\.\d{2})?(?:\s*(?:million|billion|thousand|m|bn|k))?/gi, '<strong style="font-weight:800 !important;color:#15803d">$&</strong>');
               return safe;
             }


### PR DESCRIPTION
Closes #66

## Root cause
JS keyword regex in generated script used `\b` boundaries written as `` inside a Python triple-quoted string. Python consumed these as backspace chars, so dynamic regex boundary matching failed when results were rendered via JS.

## Change
- Updated generated JS regex token in `.github/workflows/site.yml` from `\b...\b` source-unsafe form to escaped `\\b...\\b` in Python source so emitted HTML contains correct JS `\b...\b`.

## Result
- Keyword highlighting should now persist in dynamic render (results present), matching static view behavior.
- Dollar styling unchanged.