### PR TITLE
Keep keyword text bold and remove keyword highlight background

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -225,7 +225,7 @@ jobs:
 
           def format_bullet_html(text):
               safe = html.escape(str(text or ""))
-              safe = _KEYWORD_RE.sub(lambda m: f"<strong style=\"font-weight:900 !important;background:#fef08a;color:#111827;border-radius:.18em;padding:0 .14em\">{m.group(0)}</strong>", safe)
+              safe = _KEYWORD_RE.sub(lambda m: f"<strong style=\"font-weight:900 !important;color:#111827\">{m.group(0)}</strong>", safe)
               safe = _MONEY_RE.sub(lambda m: f"<strong style=\"font-weight:800 !important;color:#15803d\">{m.group(0)}</strong>", safe)
               return safe
 
@@ -453,7 +453,7 @@ jobs:
             }
             function styleBulletText(text){
               let safe = escapeHtml(String(text || ''));
-              safe = safe.replace(/\\b(ordnance|ordinance|resolution|appeal|amendment)s?\\b/gi, '<strong style="font-weight:900 !important;background:#fef08a;color:#111827;border-radius:.18em;padding:0 .14em">$&</strong>');
+              safe = safe.replace(/\\b(ordnance|ordinance|resolution|appeal|amendment)s?\\b/gi, '<strong style="font-weight:900 !important;color:#111827">$&</strong>');
               safe = safe.replace(/(?:US\$\s*)?\$\s?\d[\d,]*(?:\.\d{2})?(?:\s*(?:million|billion|thousand|m|bn|k))?/gi, '<strong style="font-weight:800 !important;color:#15803d">$&</strong>');
               return safe;
             }


### PR DESCRIPTION
Closes #68

## Plan
1. Remove background/highlight styling from keyword emphasis wrappers.
2. Preserve strong keyword weight and color.
3. Keep money emphasis untouched.

## Changes
- Updated keyword formatter wrappers (Python static + JS dynamic) to keep `font-weight:900` but remove background/padding/border-radius highlight treatment.
- Left dollar formatting as bold green.

## Review
- [x] Keywords still bold in dynamic render.
- [x] No yellow/highlight background on keywords.
- [x] Dollar values remain bold green.