### PR TITLE
fix(ci): prevent no-op scheduled runs from wiping MeetingWatch cards

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -172,11 +172,16 @@ jobs:
           name: scrape-data
           path: ./data
 
-      - name: Prepare placeholder data for no-op scheduled runs
+      - name: Preserve prior meetings data for no-op scheduled runs
         if: ${{ github.event_name == 'schedule' && needs.scrape.outputs.should_run != 'true' }}
         run: |
+          set -euo pipefail
           mkdir -p data
-          printf '[]\n' > data/meetings.json
+          curl -fsSL "https://jysc-curator.github.io/MeetingWatch/data/meetings.json" -o data/meetings.json || true
+
+          if [ ! -s data/meetings.json ]; then
+            echo '{"meetings": []}' > data/meetings.json
+          fi
 
       - name: Prepare static site
         run: |


### PR DESCRIPTION
## What this changes
- Replaces no-op scheduled-run placeholder behavior that wrote `[]` to `data/meetings.json`.
- On no-op scheduled runs, fetches and preserves the previously deployed `meetings.json` instead.
- Falls back safely to an empty wrapped object only if previous data cannot be fetched.

## Why
Recent no-op scheduled runs were publishing empty cards to production even though the system was healthy.

Closes #73
Related: #70
