### PR TITLE
fix(ci): parser-safe quoted step name for history sanity check

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -621,7 +621,7 @@ jobs:
           PY
 
 
-      - name: Sanity check: history file is published
+      - name: "Sanity check: history file is published"
         run: |
           test -s _site/data/history.json || (echo "ERROR: _site/data/history.json missing" && exit 1)
 


### PR DESCRIPTION
Follow-up to #86: quote the sanity-check step name to avoid any YAML parser ambiguity.