### PR TITLE
fix(history): exclude future/today meetings from archive

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -71,11 +71,16 @@ def _dedupe_keep_latest(meetings: list[dict]) -> list[dict]:
     return list(deduped.values())
 
 
-def _apply_retention(meetings: list[dict], cutoff):
+def _apply_retention(meetings: list[dict], cutoff, today):
     kept = []
     for meeting in meetings:
         mdate = _parse_date(meeting.get("date"))
-        if mdate is None or mdate >= cutoff:
+        # History should include only past meetings within retention window.
+        # Exclude future/today records from history.
+        if mdate is None:
+            kept.append(meeting)
+            continue
+        if cutoff <= mdate < today:
             kept.append(meeting)
     return kept
 
@@ -176,7 +181,7 @@ def run():
 
     history_combined = existing_history + expired_from_previous + expired_from_new
     history_deduped = _dedupe_keep_latest(history_combined)
-    history_kept = _apply_retention(history_deduped, cutoff_date)
+    history_kept = _apply_retention(history_deduped, cutoff_date, today_mt)
     history_kept.sort(key=lambda m: (str(m.get("date") or ""), str(m.get("city") or ""), str(m.get("meeting_type") or "")), reverse=True)
 
     active_deduped = _dedupe_keep_latest(active_from_new)

--- a/tests/test_history_archive.py
+++ b/tests/test_history_archive.py
@@ -33,13 +33,15 @@ def test_dedupe_keep_latest_prefers_last_value_for_same_id():
     assert deduped[0]["status"] == "Completed"
 
 
-def test_retention_drops_meetings_older_than_cutoff():
+def test_retention_drops_meetings_older_than_cutoff_and_excludes_future():
     meetings = [
         {"id": "drop", "date": "2026-01-01", "city": "A", "meeting_type": "Council"},
         {"id": "keep", "date": "2026-03-01", "city": "A", "meeting_type": "Council"},
+        {"id": "future", "date": "2026-05-20", "city": "A", "meeting_type": "Council"},
+        {"id": "today", "date": "2026-04-10", "city": "A", "meeting_type": "Council"},
         {"id": "unknown", "date": "", "city": "A", "meeting_type": "Council"},
     ]
 
-    kept = _apply_retention(meetings, date(2026, 2, 1))
+    kept = _apply_retention(meetings, date(2026, 2, 1), date(2026, 4, 10))
 
     assert {m["id"] for m in kept} == {"keep", "unknown"}


### PR DESCRIPTION
Closes #89

## Summary
Fixes History view regression where future-dated meetings appeared in archived history.

## Changes
- Updated `_apply_retention` to keep only past meetings within retention window: `cutoff <= date < today`
- Kept undated records behavior intact
- Expanded archive tests to assert future/today exclusion
